### PR TITLE
Adds RBAC Permissions to Deployment

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -17,14 +17,26 @@
         "MFAPlaybookName": {
             "defaultValue": "SEEN-MFAMethods",
             "type": "String"
+        },
+        "DeployFromBranch": {
+            "defaultValue": "main",
+            "type": "String"
+        },
+        "LogAnalyticsResourceId": {
+            "defaultValue": "/subscriptions/<subid>/resourcegroups/<rgname>/providers/microsoft.operationalinsights/workspaces/<workspacename>",
+            "type": "String"
         }
     },
     "variables": {
-        "storageTemplate": "https://raw.githubusercontent.com/piaudonn/SecurityNotifications/shared/storage.json",
-        "webConnectionTemplate": "https://raw.githubusercontent.com/piaudonn/SecurityNotifications/shared/webconnections.json",
-        "configTemplate": "https://raw.githubusercontent.com/piaudonn/SecurityNotifications/shared/config.json",
-        "emailTemplate": "https://raw.githubusercontent.com/piaudonn/SecurityNotifications/shared/emailnotification.json",
-        "mfaTemplate": "https://raw.githubusercontent.com/piaudonn/SecurityNotifications/modules/MFAMethods/mfamethods.json"
+        "storageTemplate": "[concat('https://raw.githubusercontent.com/piaudonn/SecurityNotifications/', parameters('DeployFromBranch'), '/shared/storage.json')]",
+        "webConnectionTemplate": "[concat('https://raw.githubusercontent.com/piaudonn/SecurityNotifications/', parameters('DeployFromBranch'), '/shared/webconnections.json')]",
+        "configTemplate": "[concat('https://raw.githubusercontent.com/piaudonn/SecurityNotifications/', parameters('DeployFromBranch'), '/shared/config.json')]",
+        "emailTemplate": "[concat('https://raw.githubusercontent.com/piaudonn/SecurityNotifications/', parameters('DeployFromBranch'), '/shared/emailnotification.json')]",
+        "mfaTemplate": "[concat('https://raw.githubusercontent.com/piaudonn/SecurityNotifications/', parameters('DeployFromBranch'), '/modules/MFAMethods/mfamethods.json')]",
+        "storageRbacTemplate": "[concat('https://raw.githubusercontent.com/piaudonn/SecurityNotifications/', parameters('DeployFromBranch'), '/shared/rbacstorage.json')]",
+        "laRbacTemplate": "[concat('https://raw.githubusercontent.com/piaudonn/SecurityNotifications/', parameters('DeployFromBranch'), '/shared/rbacloganalytics.json')]",
+        "logAnalyticsSubscription": "[string(split(parameters('LogAnalyticsResourceId'),'/')[2])]",
+        "logAnalyticsResourceGroup": "[string(split(parameters('LogAnalyticsResourceId'),'/')[4])]"
     },
     "resources": [
         {
@@ -135,6 +147,61 @@
                     },
                     "StorageAccountName": {
                         "value": "[reference('StorageTemplate').outputs.storageAccountName.value]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2019-10-01",
+            "name": "RBACStorageTemplate",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'MFATemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'StorageTemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'ConfigTemplate')]"
+            ],
+            "properties": {
+                "mode": "incremental",
+                "templateLink": {
+                    "uri": "[variables('storageRbacTemplate')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "ConfigPrincipalId": {
+                        "value": "[reference('ConfigTemplate').outputs.resourcePrincipalID.value]"
+                    },
+                    "MfaPrincipalId": {
+                        "value": "[reference('MFATemplate').outputs.resourcePrincipalID.value]"
+                    },
+                    "StorageResourceId": {
+                        "value": "[reference('StorageTemplate').outputs.resourceID.value]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2019-10-01",
+            "name": "RBACLATemplate",
+            "subscriptionId": "[variables('logAnalyticsSubscription')]",
+            "resourceGroup": "[variables('logAnalyticsResourceGroup')]",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'MFATemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'StorageTemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'ConfigTemplate')]"
+            ],
+            "properties": {
+                "mode": "incremental",
+                "templateLink": {
+                    "uri": "[variables('laRbacTemplate')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "MfaPrincipalId": {
+                        "value": "[reference('MFATemplate').outputs.resourcePrincipalID.value]"
+                    },
+                    "LogAnalyticsResourceId": {
+                        "value": "[parameters('LogAnalyticsResourceId')]"
                     }
                 }
             }

--- a/modules/MFAMethods/mfamethods.json
+++ b/modules/MFAMethods/mfamethods.json
@@ -300,5 +300,15 @@
                 }
             }
         }
-    ]
+    ],
+    "outputs": {
+        "resourceID": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Logic/workflows', parameters('PlaybookName'))]"
+        },
+        "resourcePrincipalID": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.Logic/workflows', parameters('PlaybookName')), '2017-07-01', 'Full').identity.principalId]"
+        }
+    }
 }

--- a/shared/config.json
+++ b/shared/config.json
@@ -277,6 +277,10 @@
         "resourceID": {
             "type": "string",
             "value": "[resourceId('Microsoft.Logic/workflows', parameters('PlaybookName'))]"
+        },
+        "resourcePrincipalID": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.Logic/workflows', parameters('PlaybookName')), '2017-07-01', 'Full').identity.principalId]"
         }
     }
 }

--- a/shared/rbacloganalytics.json
+++ b/shared/rbacloganalytics.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "MfaPrincipalId": {
+            "defaultValue": "",
+            "type": "String"
+        },
+        "LogAnalyticsResourceId": {
+            "defaultValue": "",
+            "type": "String"
+        }
+    },
+    "variables": {
+        "logAnalyticsRoleId": "73c42c96-874c-492b-b04d-ab87d138a893",
+        "mfaLaGuid": "93a48cd2-ecbb-479d-b89c-b73a7a0df408"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[variables('mfaLaGuid')]",
+            "scope": "[parameters('LogAnalyticsResourceId')]",
+            "properties": {
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('logAnalyticsRoleId'))]",
+                "principalId": "[parameters('MfaPrincipalId')]"
+            }
+        }
+    ]
+}

--- a/shared/rbacstorage.json
+++ b/shared/rbacstorage.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "ConfigPrincipalId": {
+            "defaultValue": "",
+            "type": "String"
+        },
+        "MfaPrincipalId": {
+            "defaultValue": "",
+            "type": "String"
+        },
+        "StorageResourceId": {
+            "defaultValue": "",
+            "type": "String"
+        }
+    },
+    "variables": {
+        "blobRoleId": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+        "tableRoleId": "0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3",
+        "configBlobGuid": "d0165cc2-88d0-4f39-bc95-93f179bd8f8c",
+        "configTableGuid": "021146ef-89d0-4004-a284-f453cc5f0ff5",
+        "mfaTableGuid": "c9e50ba0-819a-4233-bcf8-e0a636d9139e"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[variables('configBlobGuid')]",
+            "scope": "[parameters('StorageResourceId')]",
+            "properties": {
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('blobRoleId'))]",
+                "principalId": "[parameters('ConfigPrincipalId')]"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[variables('configTableGuid')]",
+            "scope": "[parameters('StorageResourceId')]",
+            "properties": {
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('tableRoleId'))]",
+                "principalId": "[parameters('ConfigPrincipalId')]"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[variables('mfaTableGuid')]",
+            "scope": "[parameters('StorageResourceId')]",
+            "properties": {
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('tableRoleId'))]",
+                "principalId": "[parameters('MfaPrincipalId')]"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
@piaudonn as discussed, this version now includes RBAC permissions deployment to the ARM template.  When we add a GUI for the deployment later we can add a picker to get the Log Analytics workspace to make that part easier, for now you will need to manually enter the resource id.