### PR TITLE
Diagnostics

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -150,6 +150,9 @@
                 "parameters": {
                     "PlaybookName": {
                         "value": "[parameters('EmailPlaybookName')]"
+                    },
+                    "LogAnalyticsResourceId": {
+                        "value": "[parameters('LogAnalyticsResourceId')]"
                     }
                 }
             }

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -45,7 +45,11 @@
         "TestEmailPlaybookName": {
             "defaultValue": "SEEN-TestEmail",
             "type": "String"
-        },                
+        },
+        "EnableDiagnostics": {
+            "defaultValue": true,
+            "type": "bool"
+        },
         "DeployFromBranch": {
             "defaultValue": "main",
             "type": "String"
@@ -153,6 +157,9 @@
                     },
                     "LogAnalyticsResourceId": {
                         "value": "[parameters('LogAnalyticsResourceId')]"
+                    },
+                    "EnableDiagnostics": {
+                        "value": "[parameters('EnableDiagnostics')]"
                     }
                 }
             }

--- a/deploy/createUiDefinition.json
+++ b/deploy/createUiDefinition.json
@@ -220,6 +220,14 @@
                         "visible": "[if(equals(steps('deploymentTypeStep').deploymentType, 'advanced'), true, false)]"
                     },
                     {
+                        "name": "storageTextBlock1",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "We recommend using a dedicated storage account for SEEN.  If you choose to use an existing storage account, it must be in the same resource group."
+                        }
+                    },
+                    {
                         "name": "storageAccount",
                         "type": "Microsoft.Common.Section",
                         "label": "Storage Account Name",

--- a/deploy/createUiDefinition.json
+++ b/deploy/createUiDefinition.json
@@ -220,11 +220,43 @@
                         "visible": "[if(equals(steps('deploymentTypeStep').deploymentType, 'advanced'), true, false)]"
                     },
                     {
+                        "name": "laTextBlock1",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "Log Analytics Workspace"
+                        }
+                    },
+                    {
+                        "name": "logAnalyticsSelector",
+                        "type": "Microsoft.Solutions.ResourceSelector",
+                        "label": "Select Log Analytics Workspace",
+                        "resourceType": "microsoft.operationalinsights/workspaces",
+                        "options": {
+                          "filter": {
+                          }
+                        }
+                      }
+                ]
+            },
+            {
+                "name": "seenStorage",
+                "label": "Storage Setup",
+                "elements": [
+                    {
                         "name": "storageTextBlock1",
                         "type": "Microsoft.Common.TextBlock",
                         "visible": true,
                         "options": {
-                            "text": "We recommend using a dedicated storage account for SEEN.  If you choose to use an existing storage account, it must be in the same resource group."
+                            "text": "SEEN uses a storage account to store email templates and track previous runs of SEEN modules."
+                        }
+                    },
+                    {
+                        "name": "storageTextBlock2",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "We recommend using a dedicated storage account for SEEN.  If you choose to use an existing storage account, it must be in the same resource group as your SEEN deployment."
                         }
                     },
                     {
@@ -251,32 +283,14 @@
                             }
                         ],
                         "visible": true
-                    },
-                    {
-                        "name": "laTextBlock1",
-                        "type": "Microsoft.Common.TextBlock",
-                        "visible": true,
-                        "options": {
-                            "text": "Log Analytics Workspace"
-                        }
-                    },
-                    {
-                        "name": "logAnalyticsSelector",
-                        "type": "Microsoft.Solutions.ResourceSelector",
-                        "label": "Select Log Analytics Workspace",
-                        "resourceType": "microsoft.operationalinsights/workspaces",
-                        "options": {
-                          "filter": {
-                          }
-                        }
-                      }
+                    }
                 ]
             }
         ],
         "outputs": {
-            "StorageAccountName": "[steps('seenModules').storageAccount.singleStorage.name]",
-            "StorageAccountType": "[steps('seenModules').storageAccount.singleStorage.type]",
-            "StorageAccountKind": "[steps('seenModules').storageAccount.singleStorage.kind]",
+            "StorageAccountName": "[steps('seenStorage').storageAccount.singleStorage.name]",
+            "StorageAccountType": "[steps('seenStorage').storageAccount.singleStorage.type]",
+            "StorageAccountKind": "[steps('seenStorage').storageAccount.singleStorage.kind]",
             "LogAnalyticsResourceId": "[steps('seenModules').logAnalyticsSelector.id]",
             "ConfigPlaybookName": "[coalesce(steps('seenModules').advancedSetup.ConfigPlaybookName,'SEEN-Config')]",
             "EmailPlaybookName": "[coalesce(steps('seenModules').advancedSetup.EmailPlaybookName,'SEEN-SendEmail')]",

--- a/deploy/createUiDefinition.json
+++ b/deploy/createUiDefinition.json
@@ -182,6 +182,31 @@
                                 "visible": true
                             },
                             {
+                                "name": "enableDiagnostics",
+                                "type": "Microsoft.Common.DropDown",
+                                "label": "Enable Diagnostic Logging",
+                                "placeholder": "",
+                                "defaultValue": "True",
+                                "toolTip": "",
+                                "multiselect": false,
+                                "selectAll": false,
+                                "multiLine": false,
+                                "constraints": {
+                                  "allowedValues": [
+                                    {
+                                      "label": "True",
+                                      "value": true
+                                    },
+                                    {
+                                      "label": "False",
+                                      "value": false
+                                    }
+                                  ],
+                                  "required": true
+                                },
+                                "visible": true
+                            },
+                            {
                                 "name": "DeploymentBranch",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "Deploy from a specific GitHub Branch",
@@ -251,6 +276,7 @@
             "TravelPlaybookName": "[coalesce(steps('seenModules').advancedSetup.TravelPlaybookName,'SEEN-Travel')]",
             "TAPPlaybookName": "[coalesce(steps('seenModules').advancedSetup.TAPPlaybookName,'SEEN-TemporaryAccessPass')]",
             "WorkbookName": "[coalesce(steps('seenModules').advancedSetup.WorkbookName,'SEEN-Manage and monitor')]",
+            "EnableDiagnostics": "[coalesce(steps('seenModules').advancedSetup.enableDiagnostics, true)]",
             "DeployFromBranch": "[coalesce(steps('seenModules').advancedSetup.DeploymentBranch,'main')]",
             "location": "[location()]"
         }

--- a/shared/emailnotification.json
+++ b/shared/emailnotification.json
@@ -17,6 +17,10 @@
         "LogAnalyticsResourceId": {
             "defaultValue": "",
             "type": "String"
+        },
+        "EnableDiagnostics": {
+            "defaultValue": true,
+            "type": "bool"
         }
     },
     "variables": {},
@@ -181,6 +185,7 @@
             }
         },
         {
+            "condition": "[parameters('EnableDiagnostics')]",
             "type": "Microsoft.Logic/workflows/providers/diagnosticSettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('PlaybookName'), '/', 'Microsoft.Insights/send-to-la')]",

--- a/shared/emailnotification.json
+++ b/shared/emailnotification.json
@@ -13,6 +13,10 @@
         "ModuleVersion": {
             "defaultValue": "1.0",
             "type": "String"
+        },
+        "LogAnalyticsResourceId": {
+            "defaultValue": "",
+            "type": "String"
         }
     },
     "variables": {},
@@ -174,6 +178,25 @@
                     "outputs": {}
                 },
                 "parameters": {}
+            }
+        },
+        {
+            "type": "Microsoft.Logic/workflows/providers/diagnosticSettings",
+            "apiVersion": "2017-05-01-preview",
+            "name": "[concat(parameters('PlaybookName'), '/', 'Microsoft.Insights/send-to-la')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Logic/workflows', parameters('PlaybookName'))]"
+            ],
+            "properties": {
+                "workspaceId": "[parameters('LogAnalyticsResourceId')]",
+                "metrics": [],
+                "logs": [
+                    {
+                        "category": "WorkflowRuntime",
+                        "enabled": true
+                    }
+                ]
             }
         }
     ],


### PR DESCRIPTION
- Fixes #22 
- Fixes #27 

For 22, there's limited options with the GUI, so I have moved the storage deployment into its own page of the deployment GUI and put a note recommended a dedicated storage account, and indicating if you pick existing, it must be in the same RG

For 27 diagnostic logging is enabled by default, but an option exists in advanced to turn it off.  This is only deployed to the Email logic app.

[Deploy Link](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpiaudonn%2FSecurityNotifications%2Fdiagnostics%2Fdeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fpiaudonn%2FSecurityNotifications%2Fdiagnostics%2Fdeploy%2FcreateUiDefinition.json)

Deploy from Branch: ```diagnostics```

